### PR TITLE
arity of USB::DevHandle#usb_detach_kernel_driver_np should be 1

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -930,6 +930,6 @@ Init_usb()
   rb_define_method(rb_cUSB_DevHandle, "usb_get_driver_np", rusb_get_driver_np, 2);
 #endif
 #ifdef LIBUSB_HAS_DETACH_KERNEL_DRIVER_NP
-  rb_define_method(rb_cUSB_DevHandle, "usb_detach_kernel_driver_np", rusb_detach_kernel_driver_np, 2);
+  rb_define_method(rb_cUSB_DevHandle, "usb_detach_kernel_driver_np", rusb_detach_kernel_driver_np, 1);
 #endif
 }


### PR DESCRIPTION
rusb_detach_kernel_driver_np accepts self and 1 argument, but rb_define_method called with 2.
